### PR TITLE
Remove `declare(strict_types=1);`

### DIFF
--- a/templates/wp-rocket-clean.php.j2
+++ b/templates/wp-rocket-clean.php.j2
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * {{ ansible_managed }}


### PR DESCRIPTION
Because newer version of `wp eval-file` doesn't work with `declare(strict_types=1);`

Close #1